### PR TITLE
feat: navbar buttons scroll to dashboard sections (#5)

### DIFF
--- a/client/src/components/Navbar.css
+++ b/client/src/components/Navbar.css
@@ -16,6 +16,8 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-xl);
+  flex-wrap: wrap;
+  row-gap: var(--spacing-sm);
 }
 
 .navbar-logo {
@@ -27,6 +29,11 @@
   text-decoration: none;
   line-height: 1;
   flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
 }
 
 .navbar-menu {
@@ -34,16 +41,17 @@
   align-items: center;
   gap: var(--spacing-md);
   flex: 1;
-  justify-content: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
 }
 
 .navbar-menu-item {
   padding: 0.5rem var(--spacing-md);
-  background-color: transparent;
+  background-color: var(--color-bg-secondary);
   color: var(--color-text-primary);
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 1.5rem;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  font-size: 1.05rem;
   font-weight: 600;
   margin: 0;
   cursor: pointer;
@@ -51,15 +59,23 @@
   text-decoration: none;
   white-space: nowrap;
   line-height: 1.2;
+  box-shadow: var(--shadow-xs);
 }
 
 .navbar-menu-item:hover {
   background-color: var(--color-bg-tertiary);
   color: var(--color-primary);
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
 }
 
 .navbar-menu-item:active {
   transform: translateY(0);
+}
+
+.navbar-menu-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 
@@ -88,7 +104,9 @@
 
   .navbar-menu-item {
     padding: 0.5rem var(--spacing-sm);
-    font-size: 1.25rem;
+    font-size: 1rem;
+    width: 100%;
+    text-align: center;
   }
 }
 

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,38 +1,64 @@
+import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './Navbar.css'
+
+const SECTION_TITLES = [
+  { key: 'express-lane-rt', label: 'Express Lane Real-Time Performance' },
+  { key: 'mev', label: 'MEV' },
+  { key: 'express-lane', label: 'Express Lane' },
+  { key: 'timeboost', label: 'Timeboost' },
+  { key: 'timeboost-bids', label: 'Timeboost Bids' },
+]
 
 function Navbar() {
   const navigate = useNavigate()
 
+  const scrollToSection = useCallback((label: string) => {
+    if (typeof window === 'undefined') return
+
+    const sectionHeading = Array.from(
+      document.querySelectorAll<HTMLElement>('.section-title')
+    ).find((element) => element.textContent?.trim().toLowerCase() === label.toLowerCase())
+
+    if (!sectionHeading) return
+
+    const navbarHeight = document.querySelector('.navbar')?.clientHeight || 0
+    const offset = 12
+    const targetPosition =
+      sectionHeading.getBoundingClientRect().top + window.scrollY - navbarHeight - offset
+
+    window.scrollTo({
+      top: Math.max(targetPosition, 0),
+      behavior: 'smooth',
+    })
+  }, [])
+
+  const handleLogoClick = useCallback(() => {
+    navigate('/')
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [navigate])
+
   return (
     <nav className="navbar">
       <div className="navbar-container">
-        <h1 
-          className="navbar-logo" 
-          onClick={() => navigate('/')} 
-          style={{ cursor: 'pointer' }}
+        <button
+          type="button"
+          className="navbar-logo"
+          onClick={handleLogoClick}
         >
           MevScan
-        </h1>
-        <div className="navbar-menu">
-          <h2 
-            className="navbar-menu-item"
-            onClick={() => navigate('/')}
-          >
-            Home
-          </h2>
-          <h2 
-            className="navbar-menu-item"
-            onClick={() => navigate('/dashboard')}
-          >
-            Dashboard
-          </h2>
-          <h2 
-            className="navbar-menu-item"
-            onClick={() => navigate('/ask')}
-          >
-            Ask
-          </h2>
+        </button>
+        <div className="navbar-menu" role="navigation" aria-label="Section navigation">
+          {SECTION_TITLES.map((section) => (
+            <button
+              key={section.key}
+              type="button"
+              className="navbar-menu-item"
+              onClick={() => scrollToSection(section.label)}
+            >
+              {section.label}
+            </button>
+          ))}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- replace navbar menu with dashboard section title buttons
- add smooth scrolling to matching section headings
- update navbar styling for button layout and mobile wrapping

Closes #5

## Test plan
- ReadLints on client/src/components/Navbar.tsx and Navbar.css