### PR TITLE
fix(chartcard): remove title underline and correct class name

### DIFF
--- a/client/src/components/ChartCard.css
+++ b/client/src/components/ChartCard.css
@@ -43,7 +43,7 @@
   min-height: 200px;
 }
 
-.chard-card-title {
+.chart-card-title {
   margin-bottom: 20px;
   font-weight: 600;
   letter-spacing: 0.5px;
@@ -55,16 +55,5 @@
   font-size: 1.25rem;
   position: relative;
   padding-bottom: 8px;
-}
-
-.chard-card-title::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 50px;
-  height: 3px;
-  background: linear-gradient(135deg, #374151 0%, #6b7280 100%);
-  border-radius: 2px;
 }
 

--- a/client/src/components/ChartCard.tsx
+++ b/client/src/components/ChartCard.tsx
@@ -27,7 +27,7 @@ function ChartCard({
   return (
     <Card className={cardClassName}>
       <CardContent className={mergedContentClassName}>
-        <Typography variant="h5" component="h2" className="chard-card-title">
+        <Typography variant="h5" component="h2" className="chart-card-title">
           {title}
         </Typography>
         {isLoading ? (


### PR DESCRIPTION
- Remove the decorative title underline (CSS ::after)
- Fix class name typo: chard-card-title → chart-card-title\n\nNo functional changes beyond styling.